### PR TITLE
Fix duplicate imports

### DIFF
--- a/src/forecastkernel/scripts/baseline_sf.py
+++ b/src/forecastkernel/scripts/baseline_sf.py
@@ -2,8 +2,6 @@
 
 import os
 import sys
-import sys
-import os
 import shutil
 # Add project root to sys.path
 # sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -26,7 +24,6 @@ from forecastkernel.core.evaluation import evaluate_forecasts
 from forecastkernel.core.forecastability import compute_forecastability_metrics
 from forecastkernel.pipelines.visuals import visual_debug
 from forecastkernel.core.phase_handler import include_dm_test, include_drift_monitor, include_serve_hash
-from forecastkernel.utils.hash_utils import compute_file_hash
 from forecastkernel.core.hash_utils import generate_serve_hash
 from forecastkernel.core.decomposition import decompose_errors
 from forecastkernel.utils.git_utils import get_git_commit_hash


### PR DESCRIPTION
## Summary
- clean up duplicate imports in `baseline_sf.py`

## Testing
- `pip install pandas statsmodels scikit-learn pandera -q`
- `pytest -q` *(fails: SchemaError in `test_valid_input_passes`)*

------
https://chatgpt.com/codex/tasks/task_e_6846e928adf4832d8134c0f229c47c18