### PR TITLE
Add data preflight script

### DIFF
--- a/docs/Documentation Log.md
+++ b/docs/Documentation Log.md
@@ -26,6 +26,23 @@ This document captures the step-by-step progression of building and validating a
 
 ---
 
+## Phase 0a: Data Pre-Flight
+
+**Goal:** Validate raw inputs for schema drift before running models.
+
+### Key Actions
+
+* Added `data_preflight.py` using DuckDB and Pandera for validation.
+* Runs optional Great Expectations checks when available.
+* Produces a `preflight_report.json` summarising pass/fail.
+
+### Key Files
+
+* `scripts/data_preflight.py`
+* `preflight_report.json`
+
+---
+
 ## Phase 1: Baseline Forecast Generation
 
 **Goal:** Build deterministic forecasts with clear scoring and evaluation.

--- a/src/forecastkernel/scripts/data_preflight.py
+++ b/src/forecastkernel/scripts/data_preflight.py
@@ -1,0 +1,71 @@
+import argparse
+import json
+from datetime import datetime
+
+import duckdb
+import pandas as pd
+
+from forecastkernel.schemas.input_schema import forecast_input_schema
+from forecastkernel.utils.logging_utils import setup_logger
+
+
+def run_preflight(input_path: str, report_path: str) -> dict:
+    """Validate raw data using Pandera and optional Great Expectations."""
+    log = setup_logger(None, "preflight")
+    log.info("Loading dataset via duckdb ...")
+    con = duckdb.connect()
+    df = con.execute(f"SELECT * FROM read_csv_auto('{input_path}')").fetch_df()
+
+    report = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "input_file": input_path,
+        "row_count": len(df),
+        "columns": list(df.columns),
+    }
+
+    try:
+        forecast_input_schema.validate(df)
+        report["pandera_pass"] = True
+    except Exception as exc:  # broad exception -> fail-fast
+        log.exception("Pandera validation failed")
+        report["pandera_pass"] = False
+        report["pandera_error"] = str(exc)
+
+    try:
+        import great_expectations as ge  # type: ignore
+
+        ge_df = ge.from_pandas(df)
+        ge_df.expect_column_values_to_not_be_null("ds")
+        ge_df.expect_column_values_to_not_be_null("unique_id")
+        ge_df.expect_column_values_to_not_be_null("y")
+        ge_result = ge_df.validate()
+        report["great_expectations_pass"] = ge_result["success"]
+        report["great_expectations_results"] = ge_result["statistics"]
+    except ImportError:
+        log.warning("Great Expectations not installed; skipping checks")
+        report["great_expectations_pass"] = None
+    except Exception as exc:  # catch any ge errors
+        log.exception("Great Expectations validation failed")
+        report["great_expectations_pass"] = False
+        report["great_expectations_error"] = str(exc)
+
+    with open(report_path, "w") as f:
+        json.dump(report, f, indent=2)
+
+    log.info(f"Preflight report saved to {report_path}")
+    if report.get("pandera_pass") is not True or report.get("great_expectations_pass") is False:
+        raise ValueError("Data preflight checks failed")
+
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Phase 0a Data Pre-Flight")
+    parser.add_argument("--input", type=str, required=True, help="Path to raw CSV file")
+    parser.add_argument("--output", type=str, default="preflight_report.json", help="Path for JSON report")
+    args = parser.parse_args()
+    run_preflight(args.input, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,19 @@
+import os
+import pandas as pd
+from forecastkernel.scripts.data_preflight import run_preflight
+
+def test_preflight_run(tmp_path):
+    df = pd.DataFrame({
+        "ds": pd.date_range("2024-01-01", periods=3, freq="D"),
+        "unique_id": ["A"] * 3,
+        "y": [1.0, 2.0, 3.0],
+    })
+    csv_path = tmp_path / "sample.csv"
+    df.to_csv(csv_path, index=False)
+    report_path = tmp_path / "report.json"
+
+    report = run_preflight(str(csv_path), str(report_path))
+
+    assert report["pandera_pass"] is True
+    assert report["row_count"] == 3
+    assert os.path.exists(report_path)


### PR DESCRIPTION
## Summary
- implement `data_preflight.py` for Phase 0a checks
- document Phase 0a workflow
- add unit test covering the script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c19665ab4832da9d701db58a0ccbc