### PR TITLE
Add cascade helper and anchor bias output

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ python -m forecastkernel.scripts.baseline_sf \
 
 Results are written to `data/outputs/baseline`.
 
+### 5. Cascade from a parent run
+
+Validate an upstream run and launch the baseline pipeline with its forecasts as the anchor:
+
+```bash
+python -m forecastkernel.scripts.cascade \
+  --parent_run data/outputs/baseline/parent -- \
+  --data data/raw/univariate_example.csv \
+  --horizon 14 --tag child
+```
+
+The resulting `baseline_metrics.json` will include an `anchor_bias` summary.
+
 ## Data versioning with DVC
 
 Data outputs are tracked with [DVC](https://dvc.org/):

--- a/src/forecastkernel/scripts/cascade.py
+++ b/src/forecastkernel/scripts/cascade.py
@@ -1,0 +1,37 @@
+import argparse
+import subprocess
+import sys
+
+from forecastkernel.core.aggregation import enforce_cascade_checks
+
+
+def main() -> None:
+    """Validate parent run then launch ``baseline_sf`` with ``--parent_run``."""
+    parser = argparse.ArgumentParser(description="Cascade baseline run from parent outputs")
+    parser.add_argument("--parent_run", type=str, required=True, help="Path to parent run directory")
+    parser.add_argument(
+        "baseline_args",
+        nargs=argparse.REMAINDER,
+        help="Additional args for baseline_sf (use '--' before these)"
+    )
+    args = parser.parse_args()
+
+    enforce_cascade_checks(args.parent_run)
+
+    extra_args = args.baseline_args
+    if extra_args and extra_args[0] == "--":
+        extra_args = extra_args[1:]
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "forecastkernel.scripts.baseline_sf",
+        "--parent_run",
+        args.parent_run,
+    ] + extra_args
+
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- compute anchor bias regardless of phase
- create `cascade.py` wrapper to enforce parent CI then call baseline
- document cascade workflow and argument passing
- handle `--` in cascade script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68529bd4d71c832d8aa2db124d8092f9